### PR TITLE
Regel für Traffic an die NAT IP eingefügt

### DIFF
--- a/bgp-konzentrator-setup.sh
+++ b/bgp-konzentrator-setup.sh
@@ -100,6 +100,7 @@ iface tun-ffrl-uplink inet static
 	address ${my_ffrl_exit_ipv4}
 	netmask 255.255.255.255
 	pre-up ip link add \$IFACE type dummy
+	pre-up ip rule add from ${my_ffrl_exit_ipv4}/32 lookup 42
 	post-down ip link del \$IFACE
 
 # Konfiguration Backbone-Anbindung Berlin A


### PR DESCRIPTION
Behebt, dass der Router nicht über die exit IP erreichbar ist.